### PR TITLE
use string buider to concate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/andanhm/go-prettytime
 
+go 1.15
+
 require (
 	github.com/sqs/goreturns v0.0.0-20180302073349-83e02874ec12 // indirect
 	golang.org/x/tools v0.0.0-20180831211245-7ca132754999 // indirect

--- a/time.go
+++ b/time.go
@@ -4,6 +4,7 @@ package prettytime
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -13,12 +14,20 @@ const infinity float64 = 31556926 * 1000
 // Handler function which determines the time difference based on defined time spams
 func handler(timeIntervalThreshold float64, timePeriod, message string) func(float64) string {
 	return func(difference float64) string {
+		var str strings.Builder
 		n := difference / timeIntervalThreshold
 		nStr := strconv.FormatFloat(n, 'f', 0, 64)
+		str.WriteString(nStr)
+		str.WriteString(" ")
+		str.WriteString(timePeriod)
 		if int(n) > 1 {
-			return "" + nStr + " " + timePeriod + "s " + message
+			str.WriteString("s ")
+			str.WriteString( message)
+			return str.String()
 		}
-		return "" + nStr + " " + timePeriod + " " + message
+		str.WriteString(" ")
+		str.WriteString( message)
+		return str.String()
 	}
 }
 

--- a/time_test.go
+++ b/time_test.go
@@ -81,3 +81,14 @@ func ExampleFormat() {
 		fmt.Printf("%s = %v\n", timeSlot.name, Format(timeSlot.t))
 	}
 }
+
+func TestFormatYear(t *testing.T) {
+	now := time.Now()
+
+	oneYearFromNow := now.AddDate(1, 0, 0)
+	gotTimeSince := Format(oneYearFromNow)
+	expected := "1 year from now"
+	if gotTimeSince != expected {
+		t.Errorf("got %v, want %v", expected, gotTimeSince)
+	}
+}


### PR DESCRIPTION
it's good to  use stings.builder or string buffer in order to concate string in golang as it does not copy the whole string in memory. A Builder is used to efficiently build a string using Write methods. It minimizes memory copying